### PR TITLE
Added LEAP/Pixelated infrastructure sites and public LEAP provider sites

### DIFF
--- a/raw/leap-pixelated-sites.txt
+++ b/raw/leap-pixelated-sites.txt
@@ -1,0 +1,6 @@
+http://leap.se
+http://bitmask.net
+http://pixelated-project.org
+http://demo.bitmask.net
+http://calyx.net
+http://try.pixelated-project.org


### PR DESCRIPTION
LEAP/Pixelated infrastructure sites
- +http://leap.se
- http://bitmask.net
- http://pixelated-project.org

Provider Sites:
- http://demo.bitmask.net
- http://calyx.net
- http://try.pixelated-project.org
